### PR TITLE
Adds a useful example to CronSequenceGenerator

### DIFF
--- a/spring-context/src/main/java/org/springframework/scheduling/support/CronSequenceGenerator.java
+++ b/spring-context/src/main/java/org/springframework/scheduling/support/CronSequenceGenerator.java
@@ -42,6 +42,7 @@ import org.springframework.util.StringUtils;
  * <li>"0 0 * * * *" = the top of every hour of every day.</li>
  * <li>"*&#47;10 * * * * *" = every ten seconds.</li>
  * <li>"0 0 8-10 * * *" = 8, 9 and 10 o'clock of every day.</li>
+ * <li>"0 * 6,19 * * *" = 6:00 AM and 7:00 PM every day.</li>
  * <li>"0 0/30 8-10 * * *" = 8:00, 8:30, 9:00, 9:30 and 10 o'clock every day.</li>
  * <li>"0 0 9-17 * * MON-FRI" = on the hour nine-to-five weekdays</li>
  * <li>"0 0 0 25 12 ?" = every Christmas Day at midnight</li>


### PR DESCRIPTION
CronSequenceGenerator didn't have the example: list of comma separated expressions. The class supports it but doesn't mention it in the examples. And every time people need this feature they have to remember that this class supports it, or Google it, or inspect the source code.
